### PR TITLE
Make multibuild installation consistent between developers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,7 @@ const build = new MultiBuild({
       })
     ],
     format: 'iife',
-    sourcemap: true
+    sourceMap: true
   },
   output: (target, input) => {
     return input

--- a/package-lock.json
+++ b/package-lock.json
@@ -4429,12 +4429,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multibuild": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multibuild/-/multibuild-2.2.0.tgz",
-      "integrity": "sha1-iWzcj+BzgQ2cwsyAz+Xk1zyZ8iw=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/multibuild/-/multibuild-2.2.1.tgz",
+      "integrity": "sha512-YElRf1Po1hNmOzjjJrxLPpgmT9DKxCT8bLhUc6jRkPa912kHO4Xya3/mWY3T3fp2o3JRDQ7rj4+vb3zeg40FDw==",
       "dev": true,
       "requires": {
-        "rollup-stream": "1.24.1",
+        "rollup-stream": "1.23.1",
         "run-sequence": "1.2.2",
         "underscore": "1.8.3",
         "vinyl-source-buffer": "1.1.1"
@@ -5245,10 +5245,13 @@
       }
     },
     "rollup": {
-      "version": "0.49.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.49.3.tgz",
-      "integrity": "sha512-n/vHRX4GhMIyGZEQRANcSFVtvz99bSRbNMuoC33ar9f4CViqffyF9WklLb2mxIQ6I/uFf7wDEpc66bXBFE7FvA==",
-      "dev": true
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.45.2.tgz",
+      "integrity": "sha512-2+bq5GQSrocdhr+M92mOQRmF1evtLRzv9NdmEC2wo7BILvTG8irHCtD0q+zg8ikNu63iJicdN5IzyxAXRTFKOQ==",
+      "dev": true,
+      "requires": {
+        "source-map-support": "0.4.18"
+      }
     },
     "rollup-plugin-babel": {
       "version": "3.0.2",
@@ -5356,12 +5359,12 @@
       }
     },
     "rollup-stream": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/rollup-stream/-/rollup-stream-1.24.1.tgz",
-      "integrity": "sha512-iQ159xbWSOPc7ey8tjEYf7pCaQwBz3ov37KNCeDewqh6Qj1gntAgZSmmEJIPs2niXMDNqVZ3rnTFXBXhZ+sYSg==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/rollup-stream/-/rollup-stream-1.23.1.tgz",
+      "integrity": "sha512-niUbTM3sqckz1FNebsSiN+koCR7RdgrRZ2HCcR4V2DT9PSs53tB4z1xzdTGxrX6bo3QT00R2sQA5n1jr/to69Q==",
       "dev": true,
       "requires": {
-        "rollup": "0.49.3"
+        "rollup": "0.45.2"
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^2.6.1",
     "gulp-watch": "^4.3.11",
-    "multibuild": "^2.2.0",
+    "multibuild": "^2.2.1",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-commonjs": "^8.2.1",
     "rollup-plugin-node-resolve": "^3.0.0",


### PR DESCRIPTION
2.2.1 isn't really compatible with 2.2.0 due to breaking changes in Rollup underneath, hence in order to have a consistent Gulpfile, we need to upgrade multibuild.