### PR TITLE
Timeout commands before the game starts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,6 +75,7 @@ const build = new MultiBuild({
             include: ['node_modules/**', 'src/common/**'],
             namedExports: {
               'src/common/GameConstants.js': [
+                'GAME_STATE',
                 'SUN_INITIAL_PROGRESS',
                 'SUN_PROGRESS_INCREMENT',
                 'SUN_UPDATE_INTERVAL_MS'

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -6,9 +6,11 @@ import React from 'react';
 import Spaceship from '/views/Spaceship';
 import Sun from '/views/Sun';
 import {
+  GAME_STATE,
   SUN_INITIAL_PROGRESS,
   SUN_UPDATE_INTERVAL_MS
 } from '/GameConstants';
+const { STARTED } = GAME_STATE;
 import TimeToStart from '/views/TimeToStart';
 import Title from '/views/Title';
 
@@ -19,7 +21,7 @@ function App(props) {
   const sunUpdateIntervalMs = (props.sunProgress === SUN_INITIAL_PROGRESS) ?
     SPACESHIP_UPDATE_INTERVAL_MS : SUN_UPDATE_INTERVAL_MS;
 
-  const spaceshipMargin = (props.state === 'started') ?
+  const spaceshipMargin = (props.state === STARTED) ?
     // If the game is in progress move the spaceship along accordingly.
     { marginLeft: `${props.progress}vw` } :
     // Otherwise center it under the title.
@@ -27,9 +29,9 @@ function App(props) {
 
   return (
     <div>
-      {(props.state === 'started') && <HUD level={props.level} />}
+      {(props.state === STARTED) && <HUD level={props.level} />}
 
-      {(props.state !== 'started') && <Title/>}
+      {(props.state !== STARTED) && <Title/>}
 
       {/* HACK(jeff): Hardcode some numbers here to sync the position of the sun and the spaceship
         * given the same values of `sunProgress` and `progress`. */}

--- a/src/common/GameConstants.js
+++ b/src/common/GameConstants.js
@@ -1,3 +1,10 @@
+// The various states of the game.
+const GAME_STATE = {
+  WAITING_FOR_PLAYERS: 0,
+  WAITING_TO_START: 1,
+  STARTED: 2
+};
+
 // How long before the sun appears on the starfield.
 const SUN_DELAY_MS = 30 * 1000;
 
@@ -20,14 +27,24 @@ const SUN_INITIAL_PROGRESS = -((SUN_DELAY_MS / SUN_UPDATE_INTERVAL_MS) * SUN_PRO
 // before the game starts.
 const TIME_TO_START_MS = 10 * 1000;
 
-// The time players are given to perform commands before the command is replaced and the ship
-// slides backwards.
-const TIME_TO_PERFORM_MS = 5 * 1000;
+// The time players are given to perform commands before the command is replaced and the ship slides
+// backwards. During the game this is done for time pressure. Before the game this is done so that
+// if a player can't figure out how to perform a command, they're not prevented from joining the
+// game, they can just wait for the next command. To give them time to figure out how the game
+// works, they get double the time to perform before the game starts.
+function timeToPerformMs(state = GAME_STATE.STARTED) {
+  let baseTime = 5 * 1000;
+  if (state !== GAME_STATE.STARTED) {
+    baseTime *= 2;
+  }
+  return baseTime;
+}
 
 module.exports = {
+  GAME_STATE,
   SUN_INITIAL_PROGRESS,
   SUN_PROGRESS_INCREMENT,
   SUN_UPDATE_INTERVAL_MS,
   TIME_TO_START_MS,
-  TIME_TO_PERFORM_MS
+  timeToPerformMs
 };

--- a/src/common/GameModelDefaults.js
+++ b/src/common/GameModelDefaults.js
@@ -1,8 +1,10 @@
-const { SUN_INITIAL_PROGRESS } = require('./GameConstants');
+const {
+  GAME_STATE: { WAITING_FOR_PLAYERS },
+  SUN_INITIAL_PROGRESS,
+} = require('./GameConstants');
 
 const defaults = {
-  // 'waiting for players', 'waiting to start', 'started'
-  state: 'waiting for players',
+  state: WAITING_FOR_PLAYERS,
   timeToStart: null,
   level: 1,
   progress: 0,

--- a/src/server/models/CommandModel.js
+++ b/src/server/models/CommandModel.js
@@ -11,13 +11,13 @@ const CommandModel = Backbone.Model.extend({
 
   _timeToPerformInterval: null,
 
-  start(timeToPerform = timeToPerformMs()) {
+  start(timeToPerform = timeToPerformMs(), announceStart = true) {
     if (this._timeToPerformInterval) {
       throw new Error('Command has already been started');
     }
 
     // Set the starting time-to-perform.
-    this.set({ timeToPerform });
+    this.set({ timeToPerform }, { silent: !announceStart });
 
     this._timeToPerformInterval = setInterval(() => {
       const timeToPerform = this.get('timeToPerform') - 1000;

--- a/src/server/models/CommandModel.js
+++ b/src/server/models/CommandModel.js
@@ -1,5 +1,5 @@
 const Backbone = require('backbone');
-const { TIME_TO_PERFORM_MS } = require('../../common/GameConstants');
+const { timeToPerformMs } = require('../../common/GameConstants');
 
 const CommandModel = Backbone.Model.extend({
   defaults: {
@@ -11,7 +11,7 @@ const CommandModel = Backbone.Model.extend({
 
   _timeToPerformInterval: null,
 
-  start(timeToPerform = TIME_TO_PERFORM_MS) {
+  start(timeToPerform = timeToPerformMs()) {
     if (this._timeToPerformInterval) {
       throw new Error('Command has already been started');
     }

--- a/src/server/models/CommandModel.js
+++ b/src/server/models/CommandModel.js
@@ -6,16 +6,18 @@ const CommandModel = Backbone.Model.extend({
     control: null,
     action: null,
     state: null,
-    completed: false,
-    timeToPerform: TIME_TO_PERFORM_MS
+    completed: false
   },
 
   _timeToPerformInterval: null,
 
-  start() {
+  start(timeToPerform = TIME_TO_PERFORM_MS) {
     if (this._timeToPerformInterval) {
       throw new Error('Command has already been started');
     }
+
+    // Set the starting time-to-perform.
+    this.set({ timeToPerform });
 
     this._timeToPerformInterval = setInterval(() => {
       const timeToPerform = this.get('timeToPerform') - 1000;

--- a/src/server/models/GameModel.js
+++ b/src/server/models/GameModel.js
@@ -275,8 +275,11 @@ const GameModel = Backbone.Model.extend({
       panel.set({ command });
       this._commands.add(command);
 
-      // Give the player a limited time to perform commands.
-      command.start(timeToPerformMs(this.get('state')));
+      // Give the player a limited time to perform commands. Once we start, skip announcing the
+      // first tick so that we don't wipe out the 'Nice job!' or 'Too late!' messages from
+      // completing the last command.
+      const announceStart = this.get('state') !== STARTED;
+      command.start(timeToPerformMs(this.get('state')), announceStart);
     };
 
     // If we're waiting to start, we assign only same-panel commands, so that we may detect if

--- a/src/server/models/GameModel.js
+++ b/src/server/models/GameModel.js
@@ -53,11 +53,6 @@ const GameModel = Backbone.Model.extend({
           if ((this.get('state') === 'started') && this._playingPanels.contains(panel)) {
             this._assignCommands();
           }
-        } else {
-          // Give the player a limited time to perform commands once the game starts.
-          if (this.get('state') === 'started') {
-            command.start();
-          }
         }
       }
     });
@@ -275,6 +270,11 @@ const GameModel = Backbone.Model.extend({
       const command = control.getCommand();
       panel.set({ command });
       this._commands.add(command);
+
+      // Give the player a limited time to perform commands once the game starts.
+      if (this.get('state') === 'started') {
+        command.start();
+      }
     };
 
     // If we're waiting to start, we assign only same-panel commands, so that we may detect if

--- a/src/server/models/GameModel.js
+++ b/src/server/models/GameModel.js
@@ -2,10 +2,11 @@ const _ = require('underscore');
 const Backbone = require('backbone');
 const defaults = require('../../common/GameModelDefaults');
 const {
+  GAME_STATE: { WAITING_FOR_PLAYERS, WAITING_TO_START, STARTED },
   SUN_PROGRESS_INCREMENT,
   SUN_UPDATE_INTERVAL_MS,
   TIME_TO_START_MS,
-  TIME_TO_PERFORM_MS
+  timeToPerformMs
 } = require('../../common/GameConstants');
 
 const GameModel = Backbone.Model.extend({
@@ -46,33 +47,26 @@ const GameModel = Backbone.Model.extend({
       },
 
       'change:command': (panel, command) => {
-        if (!command) {
-          // Assign another command when one finishes if this panel is in play.
-          // If we're waiting to start, wait to give the panel that completed the command
-          // another one until we start.
-          if ((this.get('state') === 'started') && this._playingPanels.contains(panel)) {
-            this._assignCommands();
-          }
-        }
+        if (!command) this._assignCommands();
       }
     });
 
     this._playingPanels = new Backbone.Collection();
     this.listenTo(this._playingPanels, {
       add: () => {
-        if (this.get('state') === 'waiting for players') {
-          this.set('state', 'waiting to start');
+        if (this.get('state') === WAITING_FOR_PLAYERS) {
+          this.set('state', WAITING_TO_START);
         }
       },
 
       remove: () => {
         if (this._playingPanels.isEmpty()) {
-          if (this.get('state') === 'started') {
+          if (this.get('state') === STARTED) {
             this._endGame();
           } else {
             this.set({
               timeToStart: null,
-              state: 'waiting for players'
+              state: WAITING_FOR_PLAYERS
             });
           }
         }
@@ -82,15 +76,19 @@ const GameModel = Backbone.Model.extend({
     this._commands = new Backbone.Collection();
     this.listenTo(this._commands, {
       'change:timeToPerform': (command, timeToPerform) => {
-        const assignedPanel = this._playingPanels.findWhere({ command });
+        const gameStarted = this.get('state') === STARTED;
+        const panels = gameStarted ? this._playingPanels : this.panels;
+        const assignedPanel = panels.findWhere({ command });
 
         if (timeToPerform > 0) {
-          assignedPanel.set('status', { progress: timeToPerform / TIME_TO_PERFORM_MS });
+          assignedPanel.set('status', { progress: timeToPerform / timeToPerformMs(this.get('state')) });
         } else {
-          // No need to clear this status after display since it will shortly be replaced by the
-          // new timer.
-          assignedPanel.set('status', { message: 'Too late!' });
-          this.set('progress', Math.max(this.get('progress') - 10, 0));
+          if (gameStarted) {
+            // No need to clear this status after display since it will shortly be replaced by the
+            // new timer.
+            assignedPanel.set('status', { message: 'Too late!' });
+            this.set('progress', Math.max(this.get('progress') - 10, 0));
+          }
 
           this._commands.remove(command);
           assignedPanel.unset('command');
@@ -113,13 +111,15 @@ const GameModel = Backbone.Model.extend({
           }
         }, 500);
 
-        assignedPanel.unset('command');
-
-        if (this.get('state') !== 'started') {
+        if (this.get('state') !== STARTED) {
           this._playingPanels.add(assignedPanel);
         } else {
           this.set('progress', this.get('progress') + 10);
         }
+
+        // HACK(jeff): Unset the command after potentially adding the panel to `this._playingPanels`
+        // to prevent a panel waiting to start from getting a new command.
+        assignedPanel.unset('command');
       }
     });
 
@@ -132,9 +132,9 @@ const GameModel = Backbone.Model.extend({
         clearInterval(this._sunInterval);
 
         switch (state) {
-          case 'started': {
+          case STARTED: {
             // Discard any commands on which we are waiting (from panels that didn't report during
-            // the 'waiting to start' phase).
+            // the WAITING_TO_START phase).
             this._commands.forEach((command) => this.panels.findWhere({ command }).unset('command'));
             this._commands.reset();
 
@@ -153,7 +153,7 @@ const GameModel = Backbone.Model.extend({
 
             break;
           }
-          case 'waiting to start':
+          case WAITING_TO_START:
             this.set('timeToStart', TIME_TO_START_MS);
 
             this._timeToStartInterval = setInterval(() => {
@@ -162,7 +162,7 @@ const GameModel = Backbone.Model.extend({
 
             break;
 
-          case 'waiting for players':
+          case WAITING_FOR_PLAYERS:
             // Reset the panels so that players may signal they're ready.
             this.panels.forEach((panel) => panel.unset('status'));
             this._assignCommands();
@@ -177,8 +177,8 @@ const GameModel = Backbone.Model.extend({
       'change:timeToStart': (model, timeToStart) => {
         if (_.isNumber(timeToStart)) {
           if (timeToStart <= 0) { // <= vs. === for safety belts.
-            this.set('state', 'started');
-          } else if (this.get('state') === 'waiting to start') { // Safety belts to avoid wiping out commands.
+            this.set('state', STARTED);
+          } else if (this.get('state') === WAITING_TO_START) { // Safety belts to avoid wiping out commands.
             this._playingPanels.forEach((panel) => {
               // TODO(jeff): Fix https://github.com/wearhere/spacecontrol/issues/27 so we can use …
               panel.set('display', `Game will start in ${timeToStart / 1000}...`);
@@ -247,10 +247,14 @@ const GameModel = Backbone.Model.extend({
   //     disconnected)
   //  3. One or more existing panels have finished their commands
   _assignCommands() {
-    const panels = (this.get('state') === 'started') ? this._playingPanels : this.panels;
+    const panels = (this.get('state') === STARTED) ? this._playingPanels : this.panels;
 
     // Choose as many controls to manipulate as there are panels needing commands.
-    const panelsNeedingCommands = panels.filter((panel) => !panel.has('command'));
+    // Panels waiting to start will get commands when we start.
+    const panelsNeedingCommands = panels.filter((panel) => {
+      return !panel.has('command') &&
+        !((this.get('state') === WAITING_TO_START) && this._playingPanels.contains(panel));
+    });
     if (_.isEmpty(panelsNeedingCommands)) return;
 
     const controlsToPanels = new WeakMap();
@@ -271,16 +275,14 @@ const GameModel = Backbone.Model.extend({
       panel.set({ command });
       this._commands.add(command);
 
-      // Give the player a limited time to perform commands once the game starts.
-      if (this.get('state') === 'started') {
-        command.start();
-      }
+      // Give the player a limited time to perform commands.
+      command.start(timeToPerformMs(this.get('state')));
     };
 
     // If we're waiting to start, we assign only same-panel commands, so that we may detect if
     // a player is actually at the panel. Otherwise we assign cross-panel commands too, for most
     // shouting.
-    if (this.get('state') === 'started') {
+    if (this.get('state') === STARTED) {
       controlsToAssign = _.sample(inactiveControls, panelsNeedingCommands.length);
 
       panelsNeedingCommands.forEach((panel) => {


### PR DESCRIPTION
So that if a player can't figure out how to perform a command, they're not
prevented from joining the game, they can just wait for the next command. To
give them time to figure out how the game works, they get double the time to
perform before the game starts.