### PR TITLE
Separate status messages from the progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ There are several functions you must implement:
 1. `get_state_updates` - should return any changes to panel state since the last call to this function. (hint: consider using PanelStateBase.diff_states).
 2. `get_controls` - should return the panel's available controls.
 3. `display_message` - show a message to the user.
-4. `display_status` - show a secondary, "status" message to the user. This message takes multiple
-forms--see the notes on the `'set_status`' message below.
+4. `display_status` - show a secondary, "status" message to the user.
+5. `display_progress` - Display a progress bar to the user.
+
+See the next section for recommendations on how the status and progress are to be displayed.
 
 You can instead define a `panel_main` method if you prefer to run arbitrary code (see next section).
 
@@ -101,12 +103,16 @@ entire panels dropping out.)
 When an event with `message: 'set-display'` is received, the panel should display the value of
 `data.message` on its attached display&mdash;this is the command for the player to perform.
 
-When an event with `message: 'set-status'` is received:
+When an event with `message: 'set-status'` is received, the panel should display the value of
+`data.message` on its attached display at the bottom of its display.
 
-* if `data` contains the key `message`, the panel should display `data['message']` at the bottom of
-its attached display.
-* otherwise, if `data` contains the key `progress`, the panel should display a progress bar at the
-bottom of its display, of width `floor(data['progress'] * LCD_WIDTH)`.
+When an event with `message: 'set-progress'` is received, the panel should display a progress bar
+at the bottom of its display, of width `floor(data['progress'] * LCD_WIDTH)`.
+
+*Ideally*, the panel would be able to display a display message, a status message, and a progress
+bar simultaneously. If the display is not tall enough to permit this, status messages should
+replace the progress bar, as status messages are temporary and the server will update the progress
+bar after a second anyway.
 
 When a control is manipulated, the panel should send an event like
 

--- a/panels/Panel.js
+++ b/panels/Panel.js
@@ -15,7 +15,10 @@ class Panel extends Component {
             this.display = data.message;
             break;
           case 'set-status':
-            this.status = data;
+            this.status = data.message;
+            break;
+          case 'set-progress':
+            this.progress = data.value;
             break;
         }
       })
@@ -37,7 +40,11 @@ class Panel extends Component {
     throw new Error('Subclass must override');
   }
 
-  set status(data) {
+  set status(message) {
+    throw new Error('Subclass must override');
+  }
+
+  set progress(value) {
     throw new Error('Subclass must override');
   }
 

--- a/panels/keyboardPanel.jsx
+++ b/panels/keyboardPanel.jsx
@@ -55,7 +55,8 @@ class KeyboardPanel extends Panel {
 
     this.state = {
       display: '',
-      status: null,
+      status: '',
+      progress: 0,
       input: ''
     };
   }
@@ -68,21 +69,15 @@ class KeyboardPanel extends Panel {
     this.setState({ display: message });
   }
 
-  set status(data) {
-    this.setState({ status: data });
+  set status(message) {
+    this.setState({ status: message });
+  }
+
+  set progress(value) {
+    this.setState({ progress: value });
   }
 
   render(props, state) {
-    let status;
-    if (state.status) {
-      const { message, progress } = state.status;
-      if (message) {
-        status = message;
-      } else if (progress) {
-        status = <ProgressBar columns={LCD_WIDTH} percent={progress} />;
-      }
-    }
-
     return (
       <div>
         <div>
@@ -93,7 +88,8 @@ class KeyboardPanel extends Panel {
 
         <div>
           <Text red>{state.display}</Text><br/>
-          {status}
+          <span>{state.status}</span><br/>
+          {_.isNumber(state.progress) && <ProgressBar columns={LCD_WIDTH} percent={state.progress} />}
         </div>
         <br/>
 

--- a/panels/keyboard_panel.py
+++ b/panels/keyboard_panel.py
@@ -148,14 +148,16 @@ class KeyboardPanel(PanelStateBase):
     """Prints the message with a prefix (to differentiate it from what the user types)."""
     print('> ' + message)
 
-  def display_status(self, data):
+  def display_status(self, message):
     """Prints the message with a prefix (to differentiate it from what the user types)."""
-    if 'message' in data:
-      # Ignore empty messages i.e. clearing the status.
-      if data['message']:
-        print('> ' + data['message'])
-    elif 'progress' in data:
-      print('> ' + ('█' * int(math.floor(data['progress'] * LCD_WIDTH))))
+    # Ignore empty messages i.e. clearing the status.
+    if message:
+      print('> ' + message)
+
+  def display_progress(self, value):
+    # Ignore a zero value.
+    if value:
+      print('> ' + ('█' * int(math.floor(value * LCD_WIDTH))))
 
   def __del__(self):
     self.stop_event.set()

--- a/panels/panel_client.py
+++ b/panels/panel_client.py
@@ -52,13 +52,17 @@ class PanelStateBase:
     Display a message from the server for the user."""
     raise NotImplementedError()
 
-  def display_status(self, data):
+  def display_status(self, message):
     """Must implement this function for your panel.
 
-    Display a status message from the server for the user. `data` takes multiple forms, see
-    the notes on the `'set-status'` message in the README."""
+    Display a status message from the server for the user."""
     raise NotImplementedError()
 
+  def display_progress(self, value):
+    """Must implement this function for your panel.
+
+    Display a progress bar."""
+    raise NotImplementedError()
 
 def _validate_controls(controls):
   assert isinstance(controls, list), 'Controls is not a list'
@@ -142,7 +146,9 @@ def _panel_io_subprocess_main(panel_state_factory, action_queue, message_queue, 
         if message['message'] == 'set-display':
           panel_state.display_message(message['data']['message'])
         elif message['message'] == 'set-status':
-          panel_state.display_status(message['data'])
+          panel_state.display_status(message['data']['message'])
+        elif message['message'] == 'set-progress':
+          panel_state.display_progress(message['data']['value'])
       except EmptyQueueException:
         pass
       time.sleep(MIN_LATENCY_MS / 1000)


### PR DESCRIPTION
To permit simultaneous display and to guarantee that the progress bar will
be cleared at the end of levels / the game.

Fixes https://github.com/wearhere/spacecontrol/issues/56.